### PR TITLE
動画一覧画面修正

### DIFF
--- a/app/controllers/youtube_searchs_controller.rb
+++ b/app/controllers/youtube_searchs_controller.rb
@@ -3,28 +3,23 @@ require 'active_support/all'
 class YoutubeSearchsController < ApplicationController
 
   def index
-    # 動画検索に使う路線名とカテゴリをセット
-    line_name =  "信楽高原鐵道" || " "
-    category =  nil || " "
-    # キーワードがタイトルと完全一致する動画のみを表示するために使う
-    @keyword = "信楽高原鐵道" || " "
-    @category = nil
-
-    @youtube_data = find_videos(line_name, category)
+    @youtube_data = find_videos(params[:format])
   end
   
-  def find_videos(keyword, category, after: 3.years.ago, before: Time.now)
+  def find_videos(keyword, after: 4.years.ago, before: Time.now)
     service = Google::Apis::YoutubeV3::YouTubeService.new
     # Herokuにデプロイする用
     service.key = ENV['api_key']
-
+    # キーワードがタイトルと完全一致する動画のみを表示するために使う
+    @keyword = keyword
+    
     @youtube_data = []
 
     # 検索結果を取得
     search_results = service.list_searches(
       :snippet,
       type: "video",
-      q: keyword + " " +  "前面展望" + " " + category,
+      q: keyword + " " +  "前面展望",
       max_results: 24,
       # HD 動画のみ
       video_definition: "high",

--- a/app/views/youtube_searchs/index.html.erb
+++ b/app/views/youtube_searchs/index.html.erb
@@ -1,15 +1,15 @@
-<% if !@category.blank? %>
-  <%# カテゴリを選択した場合、タイトルにキーワードと前面展望とカテゴリが含まれる動画だけを表示する %>
-  <% @youtube_data.each do |item| %>
-    <% if item[:title].include?(@keyword) && item[:title].include?("前面展望") && item[:title].include?(@category) %>
-      <iframe src="https://www.youtube.com/embed/<%= item[:video_id] %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-    <% end %>
-  <% end %>
-<% else %>
-  <%# カテゴリを選択しなかった場合、タイトルにキーワードと前面展望が含まれる動画だけを表示する %>
-  <% @youtube_data.each do |item| %>
-    <% if item[:title].include?(@keyword) && item[:title].include?("前面展望")%>
-      <iframe src="https://www.youtube.com/embed/<%= item[:video_id] %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-    <% end %>
-  <% end %>
-<% end %>
+<div class="bg-white py-6 sm:py-8">
+  <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
+    <div class="grid sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 md:gap-6">
+      <% @youtube_data.each do |item| %>
+        <%# タイトルにキーワードと前面展望を含んでいる動画だけを表示する %>
+        <% if item[:title].include?(@keyword) && item[:title].include?("前面展望")%>
+          <div class="flex flex-col group h-64 bg-gray-100 rounded-lg overflow-hidden shadow-lg relative">
+            <iframe class="w-full" height="230" src="https://www.youtube.com/embed/<%= item[:video_id] %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <div><%= item[:view_count].to_s(:delimited) %>回再生</div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### 概要
- キーワード（路線名）を含む動画のみ取得し、表示できるようにしました。
- 動画一覧画面で、動画は横3列で並ぶように修正しました。

### 確認方法
- 動画一覧に遷移したとき、動画が横3列で並んでいることを確認してください。
- 表示されている動画のタイトルは「路線名」と「前面展望」を含んでいることを確認してください。