### PR TITLE
マイページ

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,11 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
+  before_action :require_login
+
+  private
+
+  def not_authenticated
+    flash[:warning] = 'ログインしてください'
+    redirect_to login_path
+  end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,26 @@
+class ProfilesController < ApplicationController
+  before_action :set_user, only: %i[edit update]
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to profile_path, success: 'プロフィールを更新しました'
+    else
+      flash.now['error'] = 'プロフィールを更新できませんでした'
+      render :edit
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email)
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,5 @@
 class ProfilesController < ApplicationController
-  before_action :set_user, only: %i[edit update]
+  before_action :set_user, only: %i[show edit update]
 
   def show; end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,5 @@
 class ProfilesController < ApplicationController
-  before_action :set_user, only: %i[show edit update]
+  before_action :set_user, only: %i[edit update]
 
   def show; end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,7 +10,7 @@ class ProfilesController < ApplicationController
       redirect_to profile_path, success: 'プロフィールを更新しました'
     else
       flash.now['error'] = 'プロフィールを更新できませんでした'
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -1,4 +1,6 @@
 class SearchResultsController < ApplicationController
+  skip_before_action :require_login, only: %i[index show]
+
   def index
     @line = Line.ransack(params[:q])
     @lines = @line.result

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,6 +2,7 @@ class StaticPagesController < ApplicationController
   before_action :set_prefecture
   before_action :set_line
   before_action :set_category
+  skip_before_action :require_login, only: %i[top]
 
   def top; end
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,5 +1,6 @@
 class UserSessionsController < ApplicationController
-
+  skip_before_action :require_login, only: %i[new create]
+  
   def new; end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
 
   def new
     @user = User.new

--- a/app/controllers/youtube_searchs_controller.rb
+++ b/app/controllers/youtube_searchs_controller.rb
@@ -1,6 +1,7 @@
 require 'google/apis/youtube_v3'
 require 'active_support/all'
 class YoutubeSearchsController < ApplicationController
+  skip_before_action :require_login, only: %i[index]
 
   def index
     @youtube_data = find_videos(params[:format])

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,25 @@
+<div class="container flex items-center justify-center flex-1 h-full mx-auto">      
+  <div class="w-full max-w-lg">
+    <div class="leading-loose">
+      <%= form_with model: @user, url: profile_path, class: 'max-w-lg px-10 py-12 xl:mt-16 m-auto', local: true do |f| %>
+        <h1 class="mb-4 text-2xl font-bold text-center text-black-900">プロフィール編集</h1>
+        <%= render 'shared/error_messages', object: f.object %>
+        <div class="mb-3 flex-1">
+          <div class="pt-2 pb-2 text-sm">
+            <%= f.label :name %>
+          </div>
+          <%= f.text_field :name, class: 'input input-bordered w-full' %>
+        </div>
+        <div class="mb-3 flex-1">
+          <div class="pt-2 pb-2 text-sm">
+            <%= f.label :email %>
+          </div>
+          <%= f.email_field :email, class: 'input input-bordered w-full' %>
+        </div>
+        <div class="flex items-center justify-between mt-8">
+          <%= f.submit '編集を保存', type: 'submit', class: 'cursor-pointer py-2 px-4  bg-accent hover:bg-indigo-700 focus:ring-indigo-500 focus:ring-offset-indigo-200 text-white w-full transition ease-in duration-200 text-center text-base font-semibold shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2  rounded-lg' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,11 @@
+<div class="flex flex-col items-center justify-center my-10">
+  <div class="items-center justify-center mb-3">
+    <div class="py-1 text-2xl">
+      <%= @user.name %>
+    </div>
+    <div class="py-7 text-2xl">
+      <%= @user.email %>
+    </div>
+    <button class="btn btn-accent">プロフィール編集</button>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,10 +1,10 @@
 <div class="flex flex-col items-center justify-center my-10">
   <div class="items-center justify-center mb-3">
     <div class="py-1 text-2xl">
-      <%= @user.name %>
+      <%= current_user.name %>
     </div>
     <div class="py-7 text-2xl">
-      <%= @user.email %>
+      <%= current_user.email %>
     </div>
     <button class="btn btn-accent"><%= link_to 'プロフィール編集', edit_profile_path %></button>
   </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -6,6 +6,6 @@
     <div class="py-7 text-2xl">
       <%= @user.email %>
     </div>
-    <button class="btn btn-accent">プロフィール編集</button>
+    <button class="btn btn-accent"><%= link_to 'プロフィール編集', edit_profile_path %></button>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="flex-none">
     <ul class="menu menu-horizontal text-white">
-      <li><%= link_to 'プロフィール', profile_path %></li>
+      <li><%= link_to 'マイページ', profile_path %></li>
       <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete } %></li>
     </ul>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,6 +4,7 @@
   </div>
   <div class="flex-none">
     <ul class="menu menu-horizontal text-white">
+      <li><%= link_to 'プロフィール', profile_path %></li>
       <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete } %></li>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   resources :users, only: [:new, :create]
   resources :youtube_searchs, only: [:index]
   resources :search_results, only: [:index, :show]
+  resource :profile, only: [:show, :edit, :update]
 end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
- マイページ機能を追加しました。
具体的にはプロフィール詳細画面の作成とプロフィール編集ができるようにしました。

### 確認方法
- ログイン後、ヘッダーにある「マイページ」をクリックするとマイページ画面に遷移します。「プロフィール編集」をクリックし、 プロフィール編集画面に遷移する。全フォームに値を入力してから「編集を保存」をクリックするとマイページ画面に遷移して、「プロフィールを更新しました」というフラッシュメッセージが表示されることを確認してください。
- プロフィール編集画面でフォームに空値がある状態で「編集を保存」をクリックするとバリデーションエラーが発生し、プロフィール編集画面をレンダリングすることを確認してください。その時、「プロフィールを更新できませんでした」というフラッシュメッセージが表示されることも確認してください。
- ログインしていない状態でlocalhost:3000/profileにリクエストを送ると、ログイン画面にリダイレクトすると共にフラッシュメッセージで「ログインしてください」と表示されるのことを確認してください。