### PR TITLE
都道府県・鉄道路線のセレクトボックスにonchangeイベントを追加

### DIFF
--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -1,5 +1,5 @@
 class LinesController < ApplicationController
-  skip_before_action :require_login, only: %i[index show]
+  skip_before_action :require_login, only: %i[index show update_lines_options]
 
   def index
     @line = Line.ransack(params[:q])
@@ -11,5 +11,14 @@ class LinesController < ApplicationController
     @comment = Comment.new
     @comments = @line.comments.includes(:user).order(created_at: :desc)
     @commentable = @line
+  end
+
+  def update_lines_options
+    selected_prefecture_id = params[:prefecture_id]
+    lines = Line.joins(:prefecture_lines)
+                .where(prefecture_lines: { prefecture_id: selected_prefecture_id })
+                .order(:name)
+
+    render json: { lines: lines }
   end
 end

--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -3,7 +3,7 @@ class LinesController < ApplicationController
 
   def index
     @line = Line.ransack(params[:q])
-    @lines = @line.result
+    @lines = @line.result(distinct: true)
   end
 
   def show

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,3 +4,43 @@ import "controllers"
 import "@fortawesome/fontawesome-free"
 import jquery from "jquery"
 window.$ = jquery
+
+// Turbo フレームが読み込まれた際にファンクションが実行される
+document.addEventListener("turbo:load", function() {
+  // "prefecture-select" という ID を持つ要素を取得します
+  const prefectureSelect = document.getElementById("prefecture-select");
+  // "line-select" という ID を持つ要素を取得します
+  const lineSelect = document.getElementById("line-select");
+
+  // もし "prefecture-select" と "line-select" が両方とも存在する場合に処理を実行します
+  if (prefectureSelect && lineSelect) {
+    // "prefecture-select" の値が変更されたときにファンクションが実行される
+    prefectureSelect.addEventListener("change", function() {
+      // 選択された都道府県の ID を取得します
+      const selectedPrefectureId = prefectureSelect.value;
+      // 選択された都道府県に基づいて路線の選択肢を更新します
+      updateLineOptions(selectedPrefectureId);
+    });
+  }
+  // 選択された都道府県に基づいて路線の選択肢を更新する関数です
+  function updateLineOptions(selectedPrefectureId) {
+    // サーバーからデータを取得し、選択された都道府県に基づいて路線の選択肢を更新します
+    fetch(`/lines/update_lines_options?prefecture_id=${selectedPrefectureId}`)
+      .then(response => response.json()) // レスポンスを JSON 形式に変換します
+      .then(data => {
+        // 既存の選択肢をクリアします
+        lineSelect.innerHTML = "";
+
+        // 取得したデータに基づいて新しい選択肢を追加する
+        data.lines.forEach(line => {
+          const option = document.createElement("option");
+          option.value = line.id;
+          option.text = line.name;
+          lineSelect.appendChild(option);
+        });
+      })
+      .catch(error => {
+        console.error("データの取得中にエラーが発生しました:", error);
+      });
+  }
+});

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,8 +2,6 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "@fortawesome/fontawesome-free"
-import jquery from "jquery"
-window.$ = jquery
 
 // Turbo フレームが読み込まれた際にファンクションが実行される
 document.addEventListener("turbo:load", function() {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,5 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "@fortawesome/fontawesome-free"
+import jquery from "jquery"
+window.$ = jquery

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer footer-center p-10 bg-neutral text-base-content rounded">
+<footer class="footer footer-center p-6 bg-neutral text-base-content mt-12">
   <div class="grid grid-flow-col gap-4">
     <%= link_to '利用規約', class: "link link-hove" %>
     <%= link_to 'プライバシーポリシー', class: "link link-hove" %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -4,11 +4,11 @@
   </div>
 </div>
 <div class="mx-auto px-1 py-3 sm:px-1 max-w-3xl text-center">
-  <h1 class="font-serif text-3xl font-bold text-center">車窓動画を検索する</h1>
+  <h1 class="font-serif text-3xl font-bold text-center mt-14 mb-4">美しい鉄道路線を検索する</h1>
   <!-- 検索フォーム -->
   <div class="p-3.5">
     <div class="artboard-demo bg-secondary-focus sm:col-span-2 p-3.5 items-center text-center">
-      <h2 class="text-center font-bold font-serif text-xl">都道府県で検索</h2>
+      <h2 class="text-center font-bold font-serif text-xl mt-5">都道府県から検索</h2>
       <div class="sm:col-span-2 p-3.5">
         <%= search_form_for @line do |f| %>
           <%# 都道府県検索 %>
@@ -19,10 +19,16 @@
               <%= f.submit '検索' %>
             </button>
           </div>
-          <h2 class="text-center font-bold font-serif text-xl">カテゴリ検索</h2>
-          <div class="p-3.5">
-            <%= f.collection_select(:line_categories_category_id_eq, @categories, :id, :name, {include_blank: "カテゴリを選択"}, {class:"select select-bordered  max-w-xs pl-8"}) %>
-          </div>
+        <% end %>
+        <h2 class="text-center font-bold font-serif text-xl mt-14 mb-4">カテゴリから検索</h2>
+        <%= search_form_for @line do |f| %>
+          <% Category.all.each do |category| %>
+            <%= f.check_box :line_categories_category_id_eq_any, { multiple: true, checked: category[:checked], disabled: category[:disabled], include_hidden: false, class: 'checkbox checkbox-accent' }, category[:id] %>
+            <%= f.label :line_categories_category_id_eq_any, category.name, { class: 'font-bold font-serif text-lg' }, value: category[:id] %>
+          <% end %>
+          <button class="text-white bg-accent hover:bg-indigo-700 focus:ring-indigo-500 focus:ring-offset-indigo-200 rounded-lg px-4 py-2 ml-4">
+            <%= f.submit '検索' %>
+          </button>
         <% end %>
       </div>
     </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -20,7 +20,7 @@
             </button>
           </div>
         <% end %>
-        <h2 class="text-center font-bold font-serif text-xl mt-14 mb-4">カテゴリから検索</h2>
+        <h2 class="text-center font-bold font-serif text-xl mt-8 mb-4">カテゴリから検索</h2>
         <%= search_form_for @line do |f| %>
           <% Category.all.each do |category| %>
             <%= f.check_box :line_categories_category_id_eq_any, { multiple: true, checked: category[:checked], disabled: category[:disabled], include_hidden: false, class: 'checkbox checkbox-accent' }, category[:id] %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -13,8 +13,8 @@
         <%= search_form_for @line do |f| %>
           <%# 都道府県検索 %>
           <div class="p-3.5 inline-flex">
-            <%= f.collection_select(:prefecture_lines_prefecture_id_eq, @prefectures, :id, :name, {include_blank: "都道府県を選択"}, {class:"select select-bordered  max-w-xs"}) %>
-            <%= f.collection_select(:id_eq, @lines, :id, :name, {include_blank: "路線名を選択"}, {class:"select select-bordered max-w-xs pl-8 ml-4"}) %>
+            <%= f.collection_select(:prefecture_lines_prefecture_id_eq, @prefectures, :id, :name, { include_blank: "都道府県を選択" }, { class: "select select-bordered max-w-xs", id: "prefecture-select" }) %>
+            <%= f.collection_select(:id_eq, @lines, :id, :name, { include_blank: "路線名を選択" }, { class: "select select-bordered max-w-xs pl-8 ml-4", id: "line-select" }) %>
             <button class="text-white bg-accent hover:bg-indigo-700 focus:ring-indigo-500 focus:ring-offset-indigo-200 rounded-lg px-4 py-2 ml-4">
               <%= f.submit '検索' %>
             </button>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "@fortawesome/fontawesome-free", to: "https://ga.jspm.io/npm:@fortawesome/fontawesome-free@6.4.2/js/all.js"
+pin "jquery", to: "https://ga.jspm.io/npm:jquery@3.7.0/dist/jquery.js"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,4 +6,3 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "@fortawesome/fontawesome-free", to: "https://ga.jspm.io/npm:@fortawesome/fontawesome-free@6.4.2/js/all.js"
-pin "jquery", to: "https://ga.jspm.io/npm:jquery@3.7.0/dist/jquery.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,8 @@ Rails.application.routes.draw do
   resource :profile, only: [:show, :edit, :update]
   resources :lines, only: %i[index show] do
     resources :comments, only: %i[create edit update destroy]
+    collection do
+      get :update_lines_options
+    end
   end
 end


### PR DESCRIPTION
### 概要
- 都道府県のプルダウンメニューが変更されると、対応する鉄道路線のプルダウンメニューの選択肢も連動して変更されるようにしました。
- フッターの高さの変更とroundedのスタイルを消しました。
- カテゴリのセレクトボックスをチェックボックスに変更しました。あと、都道府県と鉄道路線の検索フォームから切り分けました。

### 確認方法
- トップページにある、都道府県のプルダウンメニューで大阪府を選択してください。次に鉄道路線のプルダウンメニューをクリックすると、大阪府を走る「近鉄奈良線」と「JR神戸線」だけに選択肢が絞られていることを確認してください。

### スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/1b3f697a266a72faa69ae47908f7702a.jpg)](https://gyazo.com/1b3f697a266a72faa69ae47908f7702a)

### git
[![Image from Gyazo](https://i.gyazo.com/792499b93d57cdcf807e99f0ebc7a2d4.gif)](https://gyazo.com/792499b93d57cdcf807e99f0ebc7a2d4)