### PR TITLE
検索機能を路線一覧に移動

### DIFF
--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -1,4 +1,5 @@
 class LinesController < ApplicationController
+  before_action :set_prefecture, only: %i[index]
   skip_before_action :require_login, only: %i[index show update_lines_options]
 
   def index
@@ -19,5 +20,12 @@ class LinesController < ApplicationController
                 .order(:name)
 
     render json: { lines: lines }
+  end
+
+  private
+
+  def set_prefecture
+    @prefecture = Prefecture.ransack(params[:q])
+    @prefectures = @prefecture.result
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,19 +1,5 @@
 class StaticPagesController < ApplicationController
-  before_action :set_prefecture
-  before_action :set_line
   skip_before_action :require_login, only: %i[top]
 
   def top; end
-
-  private
-
-  def set_prefecture
-    @prefecture = Prefecture.ransack(params[:q])
-    @prefectures = @prefecture.result
-  end
-
-  def set_line
-    @line = Line.ransack(params[:q])
-    @lines = @line.result
-  end
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,4 +1,12 @@
 class Prefecture < ApplicationRecord
   has_many :prefecture_lines, dependent: :destroy
   has_many :lines, through: :prefecture_lines
+
+  def self.ransackable_attributes(*)
+    ["created_at", "id", "name", "updated_at"]
+  end
+
+  def self.ransackable_associations(*)
+    ["lines", "prefecture_lines"]
+  end
 end

--- a/app/views/lines/index.html.erb
+++ b/app/views/lines/index.html.erb
@@ -1,17 +1,45 @@
-<div class="container flex items-center justify-center flex-1 h-full mx-auto">
-  <!-- 検索結果 -->
-  <div class="row">
-    <div class="col-12">
-      <h1 class="my-24 text-2xl font-bold text-center text-black-900"><%= t '.title' %></h1>
-      <div class="pb-12 flex flex-row flex-wrap justify-center">
-        <% if @lines.present? %>
-          <%= render @lines %>
-        <% else %>
-          <div class="text-center">
-            <p class="text-md flex justify-center">該当する路線が見つかりませんでした。</p>
-          </div>
+<div class="mx-auto px-1 py-3 sm:px-1 max-w-3xl text-center">
+  <!-- 検索フォーム -->
+  <div class="p-3.5">
+    <h2 class="text-center font-bold font-serif text-xl mt-5"><%= (t 'static_pages.top.prefecture') %></h2>
+    <div class="sm:col-span-2 p-3.5">
+      <%= search_form_for @line do |f| %>
+        <div class="p-3.5 inline-flex">
+          <!-- 都道府県検索 -->
+          <%= f.collection_select(:prefecture_lines_prefecture_id_eq, @prefectures, :id, :name, { include_blank: "都道府県を選択" }, { class: "select select-bordered max-w-xs", id: "prefecture-select" }) %>
+          <!-- 路線名検索 -->
+          <%= f.collection_select(:id_eq, @lines, :id, :name, { include_blank: "路線名を選択" }, { class: "select select-bordered max-w-xs pl-8 ml-4", id: "line-select" }) %>
+          <button class="text-white bg-accent hover:bg-indigo-700 focus:ring-indigo-500 focus:ring-offset-indigo-200 rounded-lg px-4 py-2 ml-4">
+            <%= f.submit (t 'defaults.search') %>
+          </button>
+        </div>
+      <% end %>
+      <h2 class="text-center font-bold font-serif text-xl mt-8 mb-4"><%= (t 'static_pages.top.category') %></h2>
+      <!-- カテゴリ検索 -->
+      <%= search_form_for @line do |f| %>
+        <% Category.all.each do |category| %>
+          <%= f.check_box :line_categories_category_id_eq_any, { multiple: true, checked: category[:checked], disabled: category[:disabled], include_hidden: false, class: 'checkbox checkbox-accent' }, category[:id] %>
+          <%= f.label :line_categories_category_id_eq_any, category.name, { class: 'font-bold font-serif text-lg' }, value: category[:id] %>
         <% end %>
-      </div>
+        <button class="text-white bg-accent hover:bg-indigo-700 focus:ring-indigo-500 focus:ring-offset-indigo-200 rounded-lg px-4 py-2 ml-4">
+          <%= f.submit (t 'defaults.search') %>
+        </button>
+      <% end %>
     </div>
+  </div>
+</div>
+<!-- 検索結果 -->
+<div class="flex justify-center">
+  <hr class="border-t-2 border-gray-100 w-7/12 mb-12">
+</div>
+<div class="container flex items-center justify-center flex-1 h-full mx-auto">
+  <div class="pb-12 flex flex-row flex-wrap justify-center">
+    <% if @lines.present? %>
+      <%= render @lines %>
+    <% else %>
+      <div class="text-center">
+        <p class="text-md flex justify-center">該当する路線が見つかりませんでした。</p>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -4,6 +4,7 @@
   </div>
   <div class="flex-none">
     <ul class="menu menu-horizontal text-white">
+      <li><%= link_to (t 'lines.index.title'), lines_path %></li>
       <li><%= link_to (t 'users.new.title'), new_user_path %></li>
       <li><%= link_to (t 'defaults.login'), login_path %></li>
     </ul>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,6 +4,7 @@
   </div>
   <div class="flex-none">
     <ul class="menu menu-horizontal text-white">
+      <li><%= link_to (t 'lines.index.title'), lines_path %></li>
       <li><%= link_to (t 'profiles.show.title'), profile_path %></li>
       <li><%= link_to (t 'defaults.logout'), logout_path, data: { turbo_method: :delete } %></li>
     </ul>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,7 +1,7 @@
 <div class="top-wrapper">
   <div class="top-inner-text">
     <h1 class="mb-10">Train Window Trip</h1>
-    <%= link_to '車窓の旅に出かける！', lines_path, class: 'cursor-pointer py-2 px-4  bg-white hover:bg-gray-200 text-rose-500 text-center text-base font-semibold shadow-md   border-2 border-rose-500 rounded-full' %>
+    <%= link_to '車窓の旅に出かける！', lines_path, class: 'cursor-pointer py-3 px-7 bg-white hover:bg-gray-200 text-rose-500 text-center text-base font-semibold shadow-md border border-rose-500 rounded-full' %>
   </div>
 </div>
 <!-- 使い方 -->

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -42,35 +42,3 @@
     </div>
   </div>
 </div>
-<div class="mx-auto px-1 py-3 sm:px-1 max-w-3xl text-center">
-  <!-- 検索フォーム -->
-  <div class="p-3.5">
-    <div class="artboard-demo bg-secondary-focus sm:col-span-2 p-3.5 items-center text-center">
-      <h2 class="text-center font-bold font-serif text-xl mt-5"><%= (t 'static_pages.top.prefecture') %></h2>
-      <div class="sm:col-span-2 p-3.5">
-        <%= search_form_for @line do |f| %>
-          <div class="p-3.5 inline-flex">
-            <%# 都道府県検索 %>
-            <%= f.collection_select(:prefecture_lines_prefecture_id_eq, @prefectures, :id, :name, { include_blank: "都道府県を選択" }, { class: "select select-bordered max-w-xs", id: "prefecture-select" }) %>
-            <%# 路線検索 %>
-            <%= f.collection_select(:id_eq, @lines, :id, :name, { include_blank: "路線名を選択" }, { class: "select select-bordered max-w-xs pl-8 ml-4", id: "line-select" }) %>
-            <button class="text-white bg-accent hover:bg-indigo-700 focus:ring-indigo-500 focus:ring-offset-indigo-200 rounded-lg px-4 py-2 ml-4">
-              <%= f.submit (t 'defaults.search') %>
-            </button>
-          </div>
-        <% end %>
-        <h2 class="text-center font-bold font-serif text-xl mt-8 mb-4"><%= (t 'static_pages.top.category') %></h2>
-        <%# カテゴリ検索 %>
-        <%= search_form_for @line do |f| %>
-          <% Category.all.each do |category| %>
-            <%= f.check_box :line_categories_category_id_eq_any, { multiple: true, checked: category[:checked], disabled: category[:disabled], include_hidden: false, class: 'checkbox checkbox-accent' }, category[:id] %>
-            <%= f.label :line_categories_category_id_eq_any, category.name, { class: 'font-bold font-serif text-lg' }, value: category[:id] %>
-          <% end %>
-          <button class="text-white bg-accent hover:bg-indigo-700 focus:ring-indigo-500 focus:ring-offset-indigo-200 rounded-lg px-4 py-2 ml-4">
-            <%= f.submit (t 'defaults.search') %>
-          </button>
-        <% end %>
-      </div>
-    </div>
-  </div>
-</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -55,7 +55,7 @@ ja:
       title: 'プロフィール編集'
   lines:
     index:
-      title: '検索結果'
+      title: '路線を探す'
     show:
       search_button: '車窓動画を見る'
   password_resets:


### PR DESCRIPTION
### 概要
- トップページにあった検索機能を路線一覧に移動させました。

### 理由
- トップはアプリの説明だけのシンプルな状態にした方がユーザーの離脱を防げるのではと思ったから。