### PR TITLE
動画モーダルの背景切り替えボタンの可視性改善

### DIFF
--- a/app/views/youtube_searchs/_modal.html.erb
+++ b/app/views/youtube_searchs/_modal.html.erb
@@ -3,13 +3,12 @@
   <div class="bg-white rounded shadow-lg w-11/12 md:w-3/4 lg:w-2/3 flex flex-col items-center">
     <iframe id="youtubeFrame" class="w-full" height="700" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </div>
-  <div class="w-full text-center mt-4 flex justify-center">
-    <button id="changeBackground" class="bg-slate-300 text-black p-2 rounded-full w-10 h-10 flex items-center justify-center transform transition-transform duration-200 hover:scale-110">
-      <i class="fa-solid fa-image"></i>
-    </button>
-  </div>
   <button id="closeModal" class="fixed top-4 right-4 z-60 bg-slate-300 text-black mt-6 mr-48 p-2 w-10 h-10 flex items-center justify-center rounded-full transform transition-transform duration-200 hover:scale-110">&times;</button>
+  <button id="changeBackground" class="fixed top-4 right-4 z-60 bg-slate-300 text-black p-2 rounded-full mt-20 mr-48 w-10 h-10 flex items-center justify-center transform transition-transform duration-200 hover:scale-110">
+    <i class="fa-solid fa-image"></i>
+  </button>
 </div>
+
 <!-- Background Change Popup -->
 <div id="backgroundPopup" class="fixed inset-0 z-60 flex items-center justify-center hidden">
   <div class="bg-white rounded shadow-lg w-[700px] h-500px overflow-auto p-4">


### PR DESCRIPTION
### 概要
- 動画モーダルの背景切り替えボタンをモーダルを閉じるボタンの下に配置されるように調整しました。
### 確認
- 動画をクリックして動画モーダルを開いた後、背景切り替えボタンをモーダルを閉じるボタンの下に配置されているのを確認してください。