### PR TITLE
季節ごとに行って欲しい路線ランキング

### DIFF
--- a/app/controllers/autumn_rankings_controller.rb
+++ b/app/controllers/autumn_rankings_controller.rb
@@ -5,11 +5,11 @@ class AutumnRankingsController < ApplicationController
   def index
     category = Category.find_by(name: '紅葉')
     @line_autumn_like_ranks = Line.joins(:line_categories, :likes)
-                          .where(line_categories: { category_id: category.id })
-                          .group('lines.id')
-                          .select('lines.*, COUNT(likes.id) AS likes_count')
-                          .order('likes_count DESC')
-                          .limit(5)
+                                  .where(line_categories: { category_id: category.id })
+                                  .group('lines.id')
+                                  .select('lines.*, COUNT(likes.id) AS likes_count')
+                                  .order('likes_count DESC')
+                                  .limit(5)
     @crown_rank = [] # 順位の配列
     last_like_count = nil # 前の行のいいね数を保存する変数
     rank = 1 # 実際の順位

--- a/app/controllers/autumn_rankings_controller.rb
+++ b/app/controllers/autumn_rankings_controller.rb
@@ -1,0 +1,38 @@
+class AutumnRankingsController < ApplicationController
+  before_action :require_login
+  before_action :crown_set
+
+  def index
+    category = Category.find_by(name: '紅葉')
+    @line_autumn_like_ranks = Line.joins(:line_categories, :likes)
+                          .where(line_categories: { category_id: category.id })
+                          .group('lines.id')
+                          .select('lines.*, COUNT(likes.id) AS likes_count')
+                          .order('likes_count DESC')
+                          .limit(5)
+    @crown_rank = [] # 順位の配列
+    last_like_count = nil # 前の行のいいね数を保存する変数
+    rank = 1 # 実際の順位
+    cnt = 1 # ループが進むたびに順位をカウントアップするための変数
+
+    @line_autumn_like_ranks.each do |line|
+      current_like_count = line.likes_count
+      rank = cnt if last_like_count != current_like_count # 現在のいいね数と前のいいね数が異なる場合、rankをcntの値に更新
+      @crown_rank.push(rank)
+      last_like_count = current_like_count
+      cnt += 1
+    end
+  end
+
+  private
+
+  def crown_set
+    @crowns = [
+      '/images/gold_crown01.png',
+      '/images/silver_crown02.png',
+      '/images/copper_crown03.png',
+      '/images/four_crown04.png',
+      '/images/five_crown05.png'
+    ]
+  end
+end

--- a/app/controllers/spring_rankings_controller.rb
+++ b/app/controllers/spring_rankings_controller.rb
@@ -1,0 +1,38 @@
+class SpringRankingsController < ApplicationController
+  before_action :require_login
+  before_action :crown_set
+
+  def index
+    category = Category.find_by(name: '桜')
+    @line_like_ranks = Line.joins(:line_categories, :likes)
+                          .where(line_categories: { category_id: category.id })
+                          .group('lines.id')
+                          .select('lines.*, COUNT(likes.id) AS likes_count')
+                          .order('likes_count DESC')
+                          .limit(5)
+    @crown_rank = [] # 順位の配列
+    last_like_count = nil # 前の行のいいね数を保存する変数
+    rank = 1 # 実際の順位
+    cnt = 1 # ループが進むたびに順位をカウントアップするための変数
+
+    @line_like_ranks.each do |line|
+      current_like_count = line.likes_count
+      rank = cnt if last_like_count != current_like_count # 現在のいいね数と前のいいね数が異なる場合、rankをcntの値に更新
+      @crown_rank.push(rank)
+      last_like_count = current_like_count
+      cnt += 1
+    end
+  end
+
+  private
+
+  def crown_set
+    @crowns = [
+      '/images/gold_crown01.png',
+      '/images/silver_crown02.png',
+      '/images/copper_crown03.png',
+      '/images/four_crown04.png',
+      '/images/five_crown05.png'
+    ]
+  end
+end

--- a/app/controllers/spring_rankings_controller.rb
+++ b/app/controllers/spring_rankings_controller.rb
@@ -4,7 +4,7 @@ class SpringRankingsController < ApplicationController
 
   def index
     category = Category.find_by(name: '桜')
-    @line_like_ranks = Line.joins(:line_categories, :likes)
+    @line_spring_like_ranks = Line.joins(:line_categories, :likes)
                           .where(line_categories: { category_id: category.id })
                           .group('lines.id')
                           .select('lines.*, COUNT(likes.id) AS likes_count')
@@ -15,7 +15,7 @@ class SpringRankingsController < ApplicationController
     rank = 1 # 実際の順位
     cnt = 1 # ループが進むたびに順位をカウントアップするための変数
 
-    @line_like_ranks.each do |line|
+    @line_spring_like_ranks.each do |line|
       current_like_count = line.likes_count
       rank = cnt if last_like_count != current_like_count # 現在のいいね数と前のいいね数が異なる場合、rankをcntの値に更新
       @crown_rank.push(rank)

--- a/app/controllers/spring_rankings_controller.rb
+++ b/app/controllers/spring_rankings_controller.rb
@@ -5,11 +5,11 @@ class SpringRankingsController < ApplicationController
   def index
     category = Category.find_by(name: '桜')
     @line_spring_like_ranks = Line.joins(:line_categories, :likes)
-                          .where(line_categories: { category_id: category.id })
-                          .group('lines.id')
-                          .select('lines.*, COUNT(likes.id) AS likes_count')
-                          .order('likes_count DESC')
-                          .limit(5)
+                                  .where(line_categories: { category_id: category.id })
+                                  .group('lines.id')
+                                  .select('lines.*, COUNT(likes.id) AS likes_count')
+                                  .order('likes_count DESC')
+                                  .limit(5)
     @crown_rank = [] # 順位の配列
     last_like_count = nil # 前の行のいいね数を保存する変数
     rank = 1 # 実際の順位

--- a/app/controllers/winter_rankings_controller.rb
+++ b/app/controllers/winter_rankings_controller.rb
@@ -1,0 +1,38 @@
+class WinterRankingsController < ApplicationController
+  before_action :require_login
+  before_action :crown_set
+
+  def index
+    category = Category.find_by(name: '雪')
+    @line_winter_like_ranks = Line.joins(:line_categories, :likes)
+                          .where(line_categories: { category_id: category.id })
+                          .group('lines.id')
+                          .select('lines.*, COUNT(likes.id) AS likes_count')
+                          .order('likes_count DESC')
+                          .limit(5)
+    @crown_rank = [] # 順位の配列
+    last_like_count = nil # 前の行のいいね数を保存する変数
+    rank = 1 # 実際の順位
+    cnt = 1 # ループが進むたびに順位をカウントアップするための変数
+
+    @line_winter_like_ranks.each do |line|
+      current_like_count = line.likes_count
+      rank = cnt if last_like_count != current_like_count # 現在のいいね数と前のいいね数が異なる場合、rankをcntの値に更新
+      @crown_rank.push(rank)
+      last_like_count = current_like_count
+      cnt += 1
+    end
+  end
+
+  private
+
+  def crown_set
+    @crowns = [
+      '/images/gold_crown01.png',
+      '/images/silver_crown02.png',
+      '/images/copper_crown03.png',
+      '/images/four_crown04.png',
+      '/images/five_crown05.png'
+    ]
+  end
+end

--- a/app/controllers/winter_rankings_controller.rb
+++ b/app/controllers/winter_rankings_controller.rb
@@ -5,11 +5,11 @@ class WinterRankingsController < ApplicationController
   def index
     category = Category.find_by(name: '雪')
     @line_winter_like_ranks = Line.joins(:line_categories, :likes)
-                          .where(line_categories: { category_id: category.id })
-                          .group('lines.id')
-                          .select('lines.*, COUNT(likes.id) AS likes_count')
-                          .order('likes_count DESC')
-                          .limit(5)
+                                  .where(line_categories: { category_id: category.id })
+                                  .group('lines.id')
+                                  .select('lines.*, COUNT(likes.id) AS likes_count')
+                                  .order('likes_count DESC')
+                                  .limit(5)
     @crown_rank = [] # 順位の配列
     last_like_count = nil # 前の行のいいね数を保存する変数
     rank = 1 # 実際の順位

--- a/app/helpers/autumn_rankings_helper.rb
+++ b/app/helpers/autumn_rankings_helper.rb
@@ -1,0 +1,2 @@
+module AutumnRankingsHelper
+end

--- a/app/helpers/spring_rankings_helper.rb
+++ b/app/helpers/spring_rankings_helper.rb
@@ -1,0 +1,2 @@
+module SpringRankingsHelper
+end

--- a/app/helpers/winter_rankings_helper.rb
+++ b/app/helpers/winter_rankings_helper.rb
@@ -1,0 +1,2 @@
+module WinterRankingsHelper
+end

--- a/app/views/autumn_rankings/index.html.erb
+++ b/app/views/autumn_rankings/index.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col items-center justify-center my-10">
-  <div class="flex justify-center text-3xl my-8">秋におすすめの路線</div>
+  <div class="flex justify-center text-3xl my-8"><%= (t 'autumn_rankings.index.title')%></div>
   <div class="ranking-content">
   <!-- Card Blog -->
   <div class="max-w-[63rem] max-h-[80rem] px-4 py-10 sm:px-6 lg:px-8 lg:pb-14 mx-auto">

--- a/app/views/autumn_rankings/index.html.erb
+++ b/app/views/autumn_rankings/index.html.erb
@@ -1,0 +1,31 @@
+<div class="flex flex-col items-center justify-center my-10">
+  <div class="flex justify-center text-3xl my-8">秋におすすめの路線</div>
+  <div class="ranking-content">
+  <!-- Card Blog -->
+  <div class="max-w-[63rem] max-h-[80rem] px-4 py-10 sm:px-6 lg:px-8 lg:pb-14 mx-auto">
+    <!-- Grid -->
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <% @line_autumn_like_ranks.zip(@crown_rank) do |result, index| %>
+        <!-- Card -->
+        <div class="group flex flex-col bg-white h-full border border-gray-200 shadow-sm rounded-xl dark:bg-slate-900 dark:border-gray-700 dark:shadow-slate-700/[.7]">
+          <div class="rank-crown flex">
+            <%= image_tag @crowns[index - 1], size: "45x45", class:"ml-2" %>
+          </div>
+          <%= image_tag result.image, class: 'h-52 w-63 flex flex-col justify-center items-center bg-blue-600' %>
+          <div class="p-4 md:p-6">
+            <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-300 dark:hover:text-white">
+              <%= result.name %>
+            </h3>
+          </div>
+          <div class="mt-auto flex border-t border-gray-200 divide-x divide-gray-200 dark:border-gray-700 dark:divide-gray-700">
+            <%= link_to (t 'lines.show.title'), line_path(result), class: 'w-full py-3 px-4 inline-flex justify-center items-center gap-2 rounded-bl-xl font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm sm:p-4 dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800'%>
+            <%= link_to (t 'lines.show.search_button'), videos_path(id: result.id), class: 'w-full py-3 px-4 inline-flex justify-center items-center gap-2 rounded-br-xl font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm sm:p-4 dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800'%>
+          </div>
+        </div>
+        <!-- End Card -->
+      <% end %>
+    </div>
+    <!-- End Grid -->
+  </div>
+  <!-- End Card Blog -->
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,6 +11,7 @@
           <ul class="p-2 bg-neutral">
             <li><%= link_to (t 'defaults.line_like_ranking'), like_rankings_path, 'data-turbo': false %></li>
             <li><%= link_to "春におすすめの路線", spring_rankings_path, 'data-turbo': false %></li>
+            <li><%= link_to "冬におすすめの路線", winter_rankings_path, 'data-turbo': false %></li>
           </ul>
         </details>
       </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,9 +10,9 @@
           <summary><%= (t 'defaults.ranking') %></summary>
           <ul class="p-2 bg-neutral">
             <li><%= link_to (t 'defaults.line_like_ranking'), like_rankings_path, 'data-turbo': false %></li>
-            <li><%= link_to "春におすすめの路線", spring_rankings_path, 'data-turbo': false %></li>
-            <li><%= link_to "秋におすすめの路線", autumn_rankings_path, 'data-turbo': false %></li>
-            <li><%= link_to "冬におすすめの路線", winter_rankings_path, 'data-turbo': false %></li>
+            <li><%= link_to (t 'defaults.line_spring_like_ranking'), spring_rankings_path, 'data-turbo': false %></li>
+            <li><%= link_to (t 'defaults.line_autumn_like_ranking'), autumn_rankings_path, 'data-turbo': false %></li>
+            <li><%= link_to (t 'defaults.line_winter_like_ranking'), winter_rankings_path, 'data-turbo': false %></li>
           </ul>
         </details>
       </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,6 +11,7 @@
           <ul class="p-2 bg-neutral">
             <li><%= link_to (t 'defaults.line_like_ranking'), like_rankings_path, 'data-turbo': false %></li>
             <li><%= link_to "春におすすめの路線", spring_rankings_path, 'data-turbo': false %></li>
+            <li><%= link_to "秋におすすめの路線", autumn_rankings_path, 'data-turbo': false %></li>
             <li><%= link_to "冬におすすめの路線", winter_rankings_path, 'data-turbo': false %></li>
           </ul>
         </details>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,6 +10,7 @@
           <summary><%= (t 'defaults.ranking') %></summary>
           <ul class="p-2 bg-neutral">
             <li><%= link_to (t 'defaults.line_like_ranking'), like_rankings_path, 'data-turbo': false %></li>
+            <li><%= link_to "春におすすめの路線", spring_rankings_path, 'data-turbo': false %></li>
           </ul>
         </details>
       </li>

--- a/app/views/spring_rankings/index.html.erb
+++ b/app/views/spring_rankings/index.html.erb
@@ -5,7 +5,7 @@
   <div class="max-w-[63rem] max-h-[80rem] px-4 py-10 sm:px-6 lg:px-8 lg:pb-14 mx-auto">
     <!-- Grid -->
     <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-      <% @line_like_ranks.zip(@crown_rank) do |result, index| %>
+      <% @line_spring_like_ranks.zip(@crown_rank) do |result, index| %>
         <!-- Card -->
         <div class="group flex flex-col bg-white h-full border border-gray-200 shadow-sm rounded-xl dark:bg-slate-900 dark:border-gray-700 dark:shadow-slate-700/[.7]">
           <div class="rank-crown flex">

--- a/app/views/spring_rankings/index.html.erb
+++ b/app/views/spring_rankings/index.html.erb
@@ -1,0 +1,31 @@
+<div class="flex flex-col items-center justify-center my-10">
+  <div class="flex justify-center text-3xl my-8">春におすすめの路線</div>
+  <div class="ranking-content">
+  <!-- Card Blog -->
+  <div class="max-w-[63rem] max-h-[80rem] px-4 py-10 sm:px-6 lg:px-8 lg:pb-14 mx-auto">
+    <!-- Grid -->
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <% @line_like_ranks.zip(@crown_rank) do |result, index| %>
+        <!-- Card -->
+        <div class="group flex flex-col bg-white h-full border border-gray-200 shadow-sm rounded-xl dark:bg-slate-900 dark:border-gray-700 dark:shadow-slate-700/[.7]">
+          <div class="rank-crown flex">
+            <%= image_tag @crowns[index - 1], size: "45x45", class:"ml-2" %>
+          </div>
+          <%= image_tag result.image, class: 'h-52 w-63 flex flex-col justify-center items-center bg-blue-600' %>
+          <div class="p-4 md:p-6">
+            <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-300 dark:hover:text-white">
+              <%= result.name %>
+            </h3>
+          </div>
+          <div class="mt-auto flex border-t border-gray-200 divide-x divide-gray-200 dark:border-gray-700 dark:divide-gray-700">
+            <%= link_to (t 'lines.show.title'), line_path(result), class: 'w-full py-3 px-4 inline-flex justify-center items-center gap-2 rounded-bl-xl font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm sm:p-4 dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800'%>
+            <%= link_to (t 'lines.show.search_button'), videos_path(id: result.id), class: 'w-full py-3 px-4 inline-flex justify-center items-center gap-2 rounded-br-xl font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm sm:p-4 dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800'%>
+          </div>
+        </div>
+        <!-- End Card -->
+      <% end %>
+    </div>
+    <!-- End Grid -->
+  </div>
+  <!-- End Card Blog -->
+</div>

--- a/app/views/spring_rankings/index.html.erb
+++ b/app/views/spring_rankings/index.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col items-center justify-center my-10">
-  <div class="flex justify-center text-3xl my-8">春におすすめの路線</div>
+  <div class="flex justify-center text-3xl my-8"><%= (t 'spring_rankings.index.title')%></div>
   <div class="ranking-content">
   <!-- Card Blog -->
   <div class="max-w-[63rem] max-h-[80rem] px-4 py-10 sm:px-6 lg:px-8 lg:pb-14 mx-auto">

--- a/app/views/winter_rankings/index.html.erb
+++ b/app/views/winter_rankings/index.html.erb
@@ -1,0 +1,31 @@
+<div class="flex flex-col items-center justify-center my-10">
+  <div class="flex justify-center text-3xl my-8">冬におすすめの路線</div>
+  <div class="ranking-content">
+  <!-- Card Blog -->
+  <div class="max-w-[63rem] max-h-[80rem] px-4 py-10 sm:px-6 lg:px-8 lg:pb-14 mx-auto">
+    <!-- Grid -->
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <% @line_winter_like_ranks.zip(@crown_rank) do |result, index| %>
+        <!-- Card -->
+        <div class="group flex flex-col bg-white h-full border border-gray-200 shadow-sm rounded-xl dark:bg-slate-900 dark:border-gray-700 dark:shadow-slate-700/[.7]">
+          <div class="rank-crown flex">
+            <%= image_tag @crowns[index - 1], size: "45x45", class:"ml-2" %>
+          </div>
+          <%= image_tag result.image, class: 'h-52 w-63 flex flex-col justify-center items-center bg-blue-600' %>
+          <div class="p-4 md:p-6">
+            <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-300 dark:hover:text-white">
+              <%= result.name %>
+            </h3>
+          </div>
+          <div class="mt-auto flex border-t border-gray-200 divide-x divide-gray-200 dark:border-gray-700 dark:divide-gray-700">
+            <%= link_to (t 'lines.show.title'), line_path(result), class: 'w-full py-3 px-4 inline-flex justify-center items-center gap-2 rounded-bl-xl font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm sm:p-4 dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800'%>
+            <%= link_to (t 'lines.show.search_button'), videos_path(id: result.id), class: 'w-full py-3 px-4 inline-flex justify-center items-center gap-2 rounded-br-xl font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm sm:p-4 dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800'%>
+          </div>
+        </div>
+        <!-- End Card -->
+      <% end %>
+    </div>
+    <!-- End Grid -->
+  </div>
+  <!-- End Card Blog -->
+</div>

--- a/app/views/winter_rankings/index.html.erb
+++ b/app/views/winter_rankings/index.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col items-center justify-center my-10">
-  <div class="flex justify-center text-3xl my-8">冬におすすめの路線</div>
+  <div class="flex justify-center text-3xl my-8"><%= (t 'winter_rankings.index.title')%></div>
   <div class="ranking-content">
   <!-- Card Blog -->
   <div class="max-w-[63rem] max-h-[80rem] px-4 py-10 sm:px-6 lg:px-8 lg:pb-14 mx-auto">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,6 +14,9 @@ ja:
     line_show_button: '路線詳細ページに戻る'
     ranking: 'ランキング'
     line_like_ranking: '人気の路線'
+    line_spring_like_ranking: '春に行って欲しい路線'
+    line_autumn_like_ranking: '秋に行って欲しい路線'
+    line_winter_like_ranking: '冬に行って欲しい路線'
     view_more_button: 'もっと見る'
     message:
       require_login: 'ログインしてください'
@@ -64,6 +67,15 @@ ja:
   like_rankings:
     index:
       title: '人気の路線 ベスト5'
+  spring_rankings:
+    index:
+      title: '春に行って欲しい路線 ベスト5'
+  autumn_rankings:
+    index:
+      title: '秋に行って欲しい路線 ベスト5'
+  winter_rankings:
+    index:
+      title: '冬に行って欲しい路線 ベスト5'
   password_resets:
     new:
       title: 'パスワードリセット申請'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,4 +18,5 @@ Rails.application.routes.draw do
     end
   end
   resources :like_rankings, only: %i[index]
+  resources :spring_rankings, only: %i[index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,4 +20,5 @@ Rails.application.routes.draw do
   resources :like_rankings, only: %i[index]
   resources :spring_rankings, only: %i[index]
   resources :winter_rankings, only: %i[index]
+  resources :autumn_rankings, only: %i[index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,5 @@ Rails.application.routes.draw do
   end
   resources :like_rankings, only: %i[index]
   resources :spring_rankings, only: %i[index]
+  resources :winter_rankings, only: %i[index]
 end

--- a/test/controllers/autumn_rankings_controller_test.rb
+++ b/test/controllers/autumn_rankings_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class AutumnRankingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get autumn_rankings_index_url
+    assert_response :success
+  end
+end

--- a/test/controllers/spring_rankings_controller_test.rb
+++ b/test/controllers/spring_rankings_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class SpringRankingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get spring_rankings_index_url
+    assert_response :success
+  end
+end

--- a/test/controllers/winter_rankings_controller_test.rb
+++ b/test/controllers/winter_rankings_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class WinterRankingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get winter_rankings_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
### 概要
- 春に行って欲しい路線ランキングを追加しました。
- 秋に行って欲しい路線ランキングを追加しました。
- 冬に行って欲しい路線ランキングを追加しました。
### 確認方法
- ログインせずに春・秋・冬それぞれの行って欲しい路線ランキングにアクセスするとログイン画面に遷移するのを確認してください。
  - 春のURL /spring_rankings
  - 秋のURL /autumn_rankings
  - 冬のURL /winter_rankings
- ヘッダーの春に行って欲しい路線のリンクをクリックすると、春に行って欲しい路線ランキングページに遷移するのを確認してください。
- ヘッダーの秋に行って欲しい路線のリンクをクリックすると、秋に行って欲しい路線ランキングページに遷移するのを確認してください。
- ヘッダーの冬に行って欲しい路線のリンクをクリックすると、冬に行って欲しい路線ランキングページに遷移するのを確認してください。