### PR TITLE
リファクタリング（ランキング周りのコントローラ）

### DIFF
--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -3,24 +3,28 @@ class RankingsController < ApplicationController
   before_action :crown_set
 
   def index
-    case params[:season]
-    when 'spring'
-      @line_like_ranks = calculate_rankings('桜')
-    when 'autumn'
-      @line_like_ranks = calculate_rankings('紅葉')
-    when 'winter'
-      @line_like_ranks = calculate_rankings('雪')
-    else
-      @line_like_ranks = Line.joins(:likes)
-                             .group('lines.id')
-                             .select('lines.*, COUNT(likes.id) AS likes_count')
-                             .order('likes_count DESC')
-                             .limit(5)
-      calculate_crown_rank(@line_like_ranks)
-    end
+    @line_like_ranks = load_rankings
+    calculate_crown_rank(@line_like_ranks) unless params[:season] == 'likes'
   end
 
   private
+
+  def load_rankings
+    case params[:season]
+    when 'spring'
+      calculate_rankings('桜')
+    when 'autumn'
+      calculate_rankings('紅葉')
+    when 'winter'
+      calculate_rankings('雪')
+    else
+      Line.joins(:likes)
+          .group('lines.id')
+          .select('lines.*, COUNT(likes.id) AS likes_count')
+          .order('likes_count DESC')
+          .limit(5)
+    end
+  end
 
   def calculate_rankings(category_name)
     category = Category.find_by(name: category_name)

--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -1,0 +1,60 @@
+class RankingsController < ApplicationController
+  before_action :require_login
+  before_action :crown_set
+
+  def index
+    case params[:season]
+    when 'spring'
+      @line_like_ranks = calculate_rankings('桜')
+    when 'autumn'
+      @line_like_ranks = calculate_rankings('紅葉')
+    when 'winter'
+      @line_like_ranks = calculate_rankings('雪')
+    else
+      @line_like_ranks = Line.joins(:likes)
+                             .group('lines.id')
+                             .select('lines.*, COUNT(likes.id) AS likes_count')
+                             .order('likes_count DESC')
+                             .limit(5)
+      calculate_crown_rank(@line_like_ranks)
+    end
+  end
+
+  private
+
+  def calculate_rankings(category_name)
+    category = Category.find_by(name: category_name)
+    line_ranks = Line.joins(:line_categories, :likes)
+                     .where(line_categories: { category_id: category.id })
+                     .group('lines.id')
+                     .select('lines.*, COUNT(likes.id) AS likes_count')
+                     .order('likes_count DESC')
+                     .limit(5)
+    calculate_crown_rank(line_ranks)
+  end
+
+  def calculate_crown_rank(line_ranks)
+    @crown_rank = []
+    last_like_count = nil
+    rank = 1
+    cnt = 1
+
+    line_ranks.each do |line|
+      current_like_count = line.likes_count
+      rank = cnt if last_like_count != current_like_count
+      @crown_rank.push(rank)
+      last_like_count = current_like_count
+      cnt += 1
+    end
+  end
+
+  def crown_set
+    @crowns = [
+      '/images/gold_crown01.png',
+      '/images/silver_crown02.png',
+      '/images/copper_crown03.png',
+      '/images/four_crown04.png',
+      '/images/five_crown05.png'
+    ]
+  end
+end

--- a/app/helpers/rankings_helper.rb
+++ b/app/helpers/rankings_helper.rb
@@ -1,0 +1,2 @@
+module RankingsHelper
+end

--- a/app/views/rankings/index.html.erb
+++ b/app/views/rankings/index.html.erb
@@ -1,0 +1,34 @@
+<div class="flex flex-col items-center justify-center my-10">
+  <div class="ranking-content">
+  <!-- Card Blog -->
+  <div class="max-w-[63rem] max-h-[80rem] px-4 py-10 sm:px-6 lg:px-8 lg:pb-14 mx-auto">
+    <!-- Grid -->
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <% @line_like_ranks.zip(@crown_rank) do |result, index| %>
+        <!-- Card -->
+        <div class="group flex flex-col bg-white h-full border border-gray-200 shadow-sm rounded-xl dark:bg-slate-900 dark:border-gray-700 dark:shadow-slate-700/[.7]">
+          <div class="rank-crown flex">
+            <%= image_tag @crowns[index - 1], size: "45x45", class:"ml-2" %>
+          </div>
+          <%= image_tag result.image, class: 'h-52 w-63 flex flex-col justify-center items-center bg-blue-600' %>
+          <div class="p-4 md:p-6">
+            <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-300 dark:hover:text-white">
+              <%= result.name %>
+            </h3>
+            <div class="flex justify-end items-center text-xl text-gray-800">
+              <i class="fa-solid fa-heart text-secondary"></i>
+              <p class="ml-1 text-lg"><%= Like.where(line_id: result.id).count %></p>
+            </div>
+          </div>
+          <div class="mt-auto flex border-t border-gray-200 divide-x divide-gray-200 dark:border-gray-700 dark:divide-gray-700">
+            <%= link_to (t 'lines.show.title'), line_path(result), class: 'w-full py-3 px-4 inline-flex justify-center items-center gap-2 rounded-bl-xl font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm sm:p-4 dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800'%>
+            <%= link_to (t 'lines.show.search_button'), videos_path(id: result.id), class: 'w-full py-3 px-4 inline-flex justify-center items-center gap-2 rounded-br-xl font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm sm:p-4 dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800'%>
+          </div>
+        </div>
+        <!-- End Card -->
+      <% end %>
+    </div>
+    <!-- End Grid -->
+  </div>
+  <!-- End Card Blog -->
+</div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -5,14 +5,6 @@
   <div class="flex-none">
     <ul class="menu menu-horizontal text-white">
       <li><%= link_to (t 'lines.index.title'), lines_path, 'data-turbo': false %></li>
-      <li>
-        <details>
-          <summary><%= (t 'defaults.ranking') %></summary>
-          <ul class="p-2 bg-neutral">
-            <li><%= link_to (t 'defaults.line_like_ranking'), like_rankings_path, 'data-turbo': false %></li>
-          </ul>
-        </details>
-      </li>
       <li><%= link_to (t 'users.new.title'), new_user_path %></li>
       <li><%= link_to (t 'defaults.login'), login_path %></li>
     </ul>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,10 +10,10 @@
         <details>
           <summary><%= (t 'defaults.ranking') %></summary>
           <ul class="p-2 bg-neutral">
-            <li><%= link_to (t 'defaults.line_like_ranking'), like_rankings_path, 'data-turbo': false %></li>
-            <li><%= link_to (t 'defaults.line_spring_like_ranking'), spring_rankings_path, 'data-turbo': false %></li>
-            <li><%= link_to (t 'defaults.line_autumn_like_ranking'), autumn_rankings_path, 'data-turbo': false %></li>
-            <li><%= link_to (t 'defaults.line_winter_like_ranking'), winter_rankings_path, 'data-turbo': false %></li>
+            <li><%= link_to (t 'defaults.line_like_ranking'), rankings_path, 'data-turbo': false %></li>
+            <li><%= link_to (t 'defaults.line_spring_like_ranking'), rankings_path(season: 'spring'), 'data-turbo': false %></li>
+            <li><%= link_to (t 'defaults.line_autumn_like_ranking'), rankings_path(season: 'autumn'), 'data-turbo': false %></li>
+            <li><%= link_to (t 'defaults.line_winter_like_ranking'), rankings_path(season: 'winter'), 'data-turbo': false %></li>
           </ul>
         </details>
       </li>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -55,7 +55,7 @@
         <hr class="border-t-2 border-gray-10 w-44">
       </div>
       <div class="mt-6">
-        <%= link_to (t 'defaults.view_more_button'), like_rankings_path, class: 'btn bg-accent text-white hover:bg-indigo-700 px-8 py-2 rounded-full transform transition-transform duration-200 hover:scale-110' %>
+        <%= link_to (t 'defaults.view_more_button'), rankings_path, class: 'btn bg-accent text-white hover:bg-indigo-700 px-8 py-2 rounded-full transform transition-transform duration-200 hover:scale-110' %>
       </div>
     </div>
     <div class="ranking-content">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,10 +18,7 @@ Rails.application.routes.draw do
       get :search
     end
   end
-  resources :like_rankings, only: %i[index]
-  resources :spring_rankings, only: %i[index]
-  resources :winter_rankings, only: %i[index]
-  resources :autumn_rankings, only: %i[index]
+  resources :rankings, only: %i[index]
   resources :password_resets
   resources :rooms, only: %i[index show] do
     resources :comments

--- a/test/controllers/rankings_controller_test.rb
+++ b/test/controllers/rankings_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class RankingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get rankings_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
### 概要

- 季節ごとのおすすめ路線ランキングと人気路線ランキングのコントローラとルーティングをリファクタリングしました。

### 変更点
- リファクタリング前は未ログインユーザーでも人気路線ランキングを使うことができましたが、リファクタリング後はログインしないと人気路線ランキングが閲覧できない仕様になりました。ただ、ログインしていなくてもトップページに人気路線ランキングの上位3位までは表示されているのでそれでカバーできるからいいかなといった感じです。

### 今後考えていること
- デコレータを使ってrankings/index.html.erb内の〇〇ランキングというタイトルを動的に変えられるようにしようと模索中です。現在はページ内にタイトルがない状態で、路線のベスト5が表示されているといった状態です。


### 画面のスクリーンショット
- 変更前の画面
[![Image from Gyazo](https://i.gyazo.com/c9997bca5458f2c81e10d6cdbe5e3c0e.jpg)](https://gyazo.com/c9997bca5458f2c81e10d6cdbe5e3c0e)

- 変更後の画面
[![Image from Gyazo](https://i.gyazo.com/94d978bd3fa0ae43cff43fa3e99b6dbb.jpg)](https://gyazo.com/94d978bd3fa0ae43cff43fa3e99b6dbb)